### PR TITLE
removed case sensitive when getting value by column name

### DIFF
--- a/src/main/scala/cz/alenkacz/db/postgresscala/PostgresAsyncRow.scala
+++ b/src/main/scala/cz/alenkacz/db/postgresscala/PostgresAsyncRow.scala
@@ -4,7 +4,7 @@ import com.github.mauricio.async.db.RowData
 
 class PostgresAsyncRow(rowData: RowData) extends Row {
   def apply(columnNumber: Int): DbValue = new PostgresAsyncDbValue(rowData(columnNumber))
-  def apply(columnName: String): DbValue = new PostgresAsyncDbValue(rowData(columnName))
+  def apply(columnName: String): DbValue = new PostgresAsyncDbValue(rowData(columnName.toLowerCase))
   def rowNumber: Int = rowData.rowNumber
 
   def length: Int = rowData.length


### PR DESCRIPTION
`rowData` contains lowercase columns names but SQL is case insensitive so if you try to get value for column e.g. `StateData` you will get exception `java.util.NoSuchElementException: key not found: StateData` but for `statedata` it works