### PR TITLE
fix inTransaction implementation to work on pooled connections as well

### DIFF
--- a/src/main/scala/cz/alenkacz/db/postgresscala/PostgresAsyncConnection.scala
+++ b/src/main/scala/cz/alenkacz/db/postgresscala/PostgresAsyncConnection.scala
@@ -41,4 +41,9 @@ class PostgresAsyncConnection(underlyingConnection: com.github.mauricio.async.db
   override def close(): Unit = Await.result(underlyingConnection.disconnect, disconnectTimeout)
 
   override def count(query: String): Future[Long] = queryValue[Long](query).map(_.getOrElse(0L))
+
+  override def inTransaction[A](f : Connection => Future[A]) : Future[A] = underlyingConnection.inTransaction { c =>
+    // the `c` here is always non-pooled connection
+    f(new PostgresAsyncConnection(c, disconnectTimeout))
+  }
 }


### PR DESCRIPTION
The previous implementation worked on non-pooled connections only.